### PR TITLE
Release v1.2.0: Add image for GitHub self-hosted runners

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -10,14 +10,7 @@ on:
       - '!main'
 
 jobs:
-  changelog:
-    uses: obervinov/_templates/.github/workflows/changelog.yaml@v1.2.8
-
   pr:
-    uses: obervinov/_templates/.github/workflows/pr.yaml@v1.2.8
-
-  # readme:
-  #   uses: obervinov/_templates/.github/workflows/readme.yaml@v1.2.8
-
+    uses: obervinov/_templates/.github/workflows/pr.yaml@v2.0.2
   images:
-    uses: obervinov/_templates/.github/workflows/images.yaml@v1.2.8
+    uses: obervinov/_templates/.github/workflows/images.yaml@v2.0.2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,15 +9,7 @@ on:
       - closed
 
 jobs:
-  changelog:
-    uses: obervinov/_templates/.github/workflows/changelog.yaml@v1.2.8
-
-  # readme:
-  #   uses: obervinov/_templates/.github/workflows/readme.yaml@v1.2.8
-
+  release:
+    uses: obervinov/_templates/.github/workflows/release.yaml@v2.0.2
   images:
-    uses: obervinov/_templates/.github/workflows/images.yaml@v1.2.8
-
-  create-release:
-    uses: obervinov/_templates/.github/workflows/release.yaml@v1.2.8
-    needs: [changelog, images]
+    uses: obervinov/_templates/.github/workflows/images.yaml@v2.0.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
 
+## v1.2.0 - 2025-01-22
+### What's Changed
+**Full Changelog**: https://github.com/obervinov/images/compare/v1.1.3...v1.2.0 by @obervinov in https://github.com/obervinov/images/pull/24
+#### 🚀 Features
+* Add `ghub` image for GitHub self-hosted runners
+* Bump workflow version to `2.0.2`
+#### 📚 Documentation
+* [Add GH Actions widgets to README.md](https://github.com/obervinov/images/issues/4)
+
+
 ## v1.1.3 - 2024-08-14
 ### What's Changed
 **Full Changelog**: https://github.com/obervinov/images/compare/v1.1.2...v1.1.3 by @obervinov in https://github.com/obervinov/images/pull/20

--- a/README.md
+++ b/README.md
@@ -1,6 +1,15 @@
 # Docker Images Repository
-
 This repository contains Dockerfiles for building Docker images.
+[![CodeQL](https://github.com/obervinov/images/actions/workflows/github-code-scanning/codeql/badge.svg)](https://github.com/obervinov/images/actions/workflows/github-code-scanning/codeql)
+[![PR](https://github.com/obervinov/images/actions/workflows/pr.yaml/badge.svg?branch=main&event=pull_request)](https://github.com/obervinov/images/actions/workflows/pr.yaml)
+[![Release](https://github.com/obervinov/images/actions/workflows/release.yaml/badge.svg)](https://github.com/obervinov/images/actions/workflows/release.yaml)
+
+![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/obervinov/images?style=for-the-badge)
+![GitHub last commit](https://img.shields.io/github/last-commit/obervinov/images?style=for-the-badge)
+![GitHub Release Date](https://img.shields.io/github/release-date/obervinov/images?style=for-the-badge)
+![GitHub issues](https://img.shields.io/github/issues/obervinov/images?style=for-the-badge)
+![GitHub repo size](https://img.shields.io/github/repo-size/obervinov/images?style=for-the-badge)
+[![License](https://img.shields.io/badge/license-MIT-green.svg?style=for-the-badge)](https://opensource.org/licenses/MIT)
 
 ## Docker Images
 
@@ -10,6 +19,7 @@ This repository contains Dockerfiles for building Docker images.
 | certbot       | Docker image for Certbot, the Let's Encrypt client. | [README](docker/certbot/README.md)      | [Manifest](docker/certbot/Dockerfile)      |
 | debug         | Docker image for debugging purposes.                | [README](docker/debug/README.md)        | [Manifest](docker/debug/Dockerfile)        |
 | glab          | Docker image for GitLab CLI tool.                   | [README](docker/glab/README.md)         | [Manifest](docker/glab/Dockerfile)         |
+| ghub          | Docker image for GitHub CLI tool.                   | [README](docker/ghub/README.md)         | [Manifest](docker/ghub/Dockerfile)         |
 | gradle        | Docker image for Gradle CI environment.             | [README](docker/gradle/README.md)       | [Manifest](docker/gradle/Dockerfile)       |
 | python        | Docker image for Python development.                | [README](docker/python/README.md)       | [Manifest](docker/python/Dockerfile)       |
 | vault         | Docker image for HashiCorp Vault.                   | [README](docker/vault/README.md)        | [Manifest](docker/vault/Dockerfile)        |
@@ -24,4 +34,4 @@ This project is licensed under the [MIT License](LICENSE).
 ## <img src="https://github.com/obervinov/_templates/blob/v1.0.5/icons/github-actions.png" width="25" title="github-actions"> GitHub Actions
 | Name  | Version |
 | ------------------------ | ----------- |
-| GitHub Actions Templates | [v1.2.8](https://github.com/obervinov/_templates/tree/v1.2.8) |
+| GitHub Actions Templates | [v2.0.2](https://github.com/obervinov/_templates/tree/v2.0.2) |

--- a/docker/ghub/Dockerfile
+++ b/docker/ghub/Dockerfile
@@ -1,21 +1,8 @@
 ### VERSIONS METADATA ###
-ARG IMAGE_VERSION=1.0.1
-ARG ALPINE_VERSION=3.20
-ARG GO_VERSION=1.22.5
-ARG VAULT_VERSION=1.17.2
-### END VERSIONS METADATA ###
-
-
-# Build release-cli from source
-FROM golang:${GO_VERSION}-alpine${ALPINE_VERSION} AS realese-cli-builder
-
-# Install dependencies
-RUN apk --no-cache add ca-certificates make git && update-ca-certificates
-RUN git clone https://gitlab.com/gitlab-org/release-cli.git
-
-# Build binary
-WORKDIR /go/release-cli
-RUN make build
+ARG IMAGE_VERSION=0.1.0
+ARG ALPINE_VERSION=3.21.2
+ARG VAULT_VERSION=1.18.3
+ARG TF_VERSION=1.9.8
 
 
 # Download vault binary
@@ -38,27 +25,41 @@ RUN apk add --update --no-cache --virtual .deps --no-cache gnupg && \
     rm -f /tmp/${PRODUCT}_${VAULT_VERSION}_linux_amd64.zip ${PRODUCT}_${VAULT_VERSION}_SHA256SUMS ${VAULT_VERSION}/${PRODUCT}_${VAULT_VERSION}_SHA256SUMS.sig && \
     apk del .deps
 
+# Download terraform binary
+FROM alpine:${ALPINE_VERSION} AS terraform-builder
+
+ARG TF_VERSION
+ENV TF_VERSION=${TF_VERSION}
+ENV PRODUCT=terraform
+RUN apk add --update --virtual .deps --no-cache gnupg && \
+    cd /tmp && \
+    wget https://releases.hashicorp.com/${PRODUCT}/${TF_VERSION}/${PRODUCT}_${TF_VERSION}_linux_amd64.zip && \
+    wget https://releases.hashicorp.com/${PRODUCT}/${TF_VERSION}/${PRODUCT}_${TF_VERSION}_SHA256SUMS && \
+    wget https://releases.hashicorp.com/${PRODUCT}/${TF_VERSION}/${PRODUCT}_${TF_VERSION}_SHA256SUMS.sig && \
+    wget -qO- https://www.hashicorp.com/.well-known/pgp-key.txt | gpg --import && \
+    gpg --verify ${PRODUCT}_${TF_VERSION}_SHA256SUMS.sig ${PRODUCT}_${TF_VERSION}_SHA256SUMS && \
+    grep ${PRODUCT}_${TF_VERSION}_linux_amd64.zip ${PRODUCT}_${TF_VERSION}_SHA256SUMS | sha256sum -c && \
+    unzip /tmp/${PRODUCT}_${TF_VERSION}_linux_amd64.zip -d /tmp && \
+    mv /tmp/${PRODUCT} /usr/local/bin/${PRODUCT} && \
+    rm -f /tmp/${PRODUCT}_${TF_VERSION}_linux_amd64.zip ${PRODUCT}_${TF_VERSION}_SHA256SUMS ${TF_VERSION}/${PRODUCT}_${TF_VERSION}_SHA256SUMS.sig && \
+    apk del .deps
 
 # Build the final image
 FROM alpine:${ALPINE_VERSION}
 
 ARG IMAGE_VERSION
 
-LABEL org.opencontainers.image.description "This image contains utilities for automating work with github self-hosted runners"
-LABEL org.opencontainers.image.url https://github.com/obervinov/images/docker-/ghub
-LABEL org.opencontainers.image.documentation https://github.com/obervinov/images/docker-/ghub/README.md
+LABEL org.opencontainers.image.description "This image contains utilities for automating work with gitlab"
+LABEL org.opencontainers.image.url https://github.com/obervinov/images/docker-/glab
+LABEL org.opencontainers.image.documentation https://github.com/obervinov/images/docker-/glab/README.md
 LABEL org.opencontainers.image.authors https://github.com/obervinov
 LABEL org.opencontainers.image.source https://github.com/obervinov/images
 LABEL org.opencontainers.image.version ${IMAGE_VERSION}
 
 RUN apk -U upgrade && apk add --no-cache \
-    glab \
     curl \
     git \
-    bash \
-    aws-cli \
-    helm
+    bash
 
-COPY --from=realese-cli-builder /go/release-cli/bin/release-cli /usr/local/bin/release-cli
-COPY --from=realese-cli-builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=vault-builder /usr/local/bin/vault /usr/local/bin/vault
+COPY --from=terraform-builder /usr/local/bin/terraform /usr/local/bin/terraform

--- a/docker/ghub/Dockerfile
+++ b/docker/ghub/Dockerfile
@@ -1,8 +1,21 @@
 ### VERSIONS METADATA ###
-ARG IMAGE_VERSION=0.1.0
-ARG ALPINE_VERSION=3.21.2
-ARG VAULT_VERSION=1.18.3
-ARG TF_VERSION=1.9.8
+ARG IMAGE_VERSION=1.0.1
+ARG ALPINE_VERSION=3.20
+ARG GO_VERSION=1.22.5
+ARG VAULT_VERSION=1.17.2
+### END VERSIONS METADATA ###
+
+
+# Build release-cli from source
+FROM golang:${GO_VERSION}-alpine${ALPINE_VERSION} AS realese-cli-builder
+
+# Install dependencies
+RUN apk --no-cache add ca-certificates make git && update-ca-certificates
+RUN git clone https://gitlab.com/gitlab-org/release-cli.git
+
+# Build binary
+WORKDIR /go/release-cli
+RUN make build
 
 
 # Download vault binary
@@ -25,24 +38,6 @@ RUN apk add --update --no-cache --virtual .deps --no-cache gnupg && \
     rm -f /tmp/${PRODUCT}_${VAULT_VERSION}_linux_amd64.zip ${PRODUCT}_${VAULT_VERSION}_SHA256SUMS ${VAULT_VERSION}/${PRODUCT}_${VAULT_VERSION}_SHA256SUMS.sig && \
     apk del .deps
 
-# Download terraform binary
-FROM alpine:${ALPINE_VERSION} AS terraform-builder
-
-ARG TF_VERSION
-ENV TF_VERSION=${TF_VERSION}
-ENV PRODUCT=terraform
-RUN apk add --update --virtual .deps --no-cache gnupg && \
-    cd /tmp && \
-    wget https://releases.hashicorp.com/${PRODUCT}/${TF_VERSION}/${PRODUCT}_${TF_VERSION}_linux_amd64.zip && \
-    wget https://releases.hashicorp.com/${PRODUCT}/${TF_VERSION}/${PRODUCT}_${TF_VERSION}_SHA256SUMS && \
-    wget https://releases.hashicorp.com/${PRODUCT}/${TF_VERSION}/${PRODUCT}_${TF_VERSION}_SHA256SUMS.sig && \
-    wget -qO- https://www.hashicorp.com/.well-known/pgp-key.txt | gpg --import && \
-    gpg --verify ${PRODUCT}_${TF_VERSION}_SHA256SUMS.sig ${PRODUCT}_${TF_VERSION}_SHA256SUMS && \
-    grep ${PRODUCT}_${TF_VERSION}_linux_amd64.zip ${PRODUCT}_${TF_VERSION}_SHA256SUMS | sha256sum -c && \
-    unzip /tmp/${PRODUCT}_${TF_VERSION}_linux_amd64.zip -d /tmp && \
-    mv /tmp/${PRODUCT} /usr/local/bin/${PRODUCT} && \
-    rm -f /tmp/${PRODUCT}_${TF_VERSION}_linux_amd64.zip ${PRODUCT}_${TF_VERSION}_SHA256SUMS ${TF_VERSION}/${PRODUCT}_${TF_VERSION}_SHA256SUMS.sig && \
-    apk del .deps
 
 # Build the final image
 FROM alpine:${ALPINE_VERSION}
@@ -57,9 +52,13 @@ LABEL org.opencontainers.image.source https://github.com/obervinov/images
 LABEL org.opencontainers.image.version ${IMAGE_VERSION}
 
 RUN apk -U upgrade && apk add --no-cache \
+    glab \
     curl \
     git \
-    bash
+    bash \
+    aws-cli \
+    helm
 
+COPY --from=realese-cli-builder /go/release-cli/bin/release-cli /usr/local/bin/release-cli
+COPY --from=realese-cli-builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=vault-builder /usr/local/bin/vault /usr/local/bin/vault
-COPY --from=terraform-builder /usr/local/bin/terraform /usr/local/bin/terraform

--- a/docker/ghub/Dockerfile
+++ b/docker/ghub/Dockerfile
@@ -44,9 +44,9 @@ FROM alpine:${ALPINE_VERSION}
 
 ARG IMAGE_VERSION
 
-LABEL org.opencontainers.image.description "This image contains utilities for automating work with gitlab"
-LABEL org.opencontainers.image.url https://github.com/obervinov/images/docker-/glab
-LABEL org.opencontainers.image.documentation https://github.com/obervinov/images/docker-/glab/README.md
+LABEL org.opencontainers.image.description "This image contains utilities for automating work with github self-hosted runners"
+LABEL org.opencontainers.image.url https://github.com/obervinov/images/docker-/ghub
+LABEL org.opencontainers.image.documentation https://github.com/obervinov/images/docker-/ghub/README.md
 LABEL org.opencontainers.image.authors https://github.com/obervinov
 LABEL org.opencontainers.image.source https://github.com/obervinov/images
 LABEL org.opencontainers.image.version ${IMAGE_VERSION}

--- a/docker/ghub/README.md
+++ b/docker/ghub/README.md
@@ -1,0 +1,24 @@
+# GitHub Actions Docker Image
+
+This Docker image provides utilities for automating work with GitHub self-hosted runners.
+
+## Features
+- **Utilities**: It comes pre-installed with essential utilities such as `terraform`, `curl`, `git`, `vault`, `bash`.
+
+## Build Process
+
+This Docker image is built in two stages:
+
+1. **Builder Stage**: This stage installs necessary dependencies, copies the source code, and builds the binary.
+   
+2. **Final Stage**: This stage uses the `alpine` base image and installs additional dependencies required for running the utilities.
+
+
+## Additional Information
+
+- **Description**: This image contains utilities for automating work with GitHub self-hosted runners.
+- **Documentation**: [GitHub Repository](https://github.com/obervinov/images/docker-/ghub/README.md)
+- **Author**: [obervinov](https://github.com/obervinov)
+- **Source Code**: [GitHub Repository](https://github.com/obervinov/images/docker-/ghub/Dockerfile)
+
+Feel free to customize this image according to your specific requirements and environment. If you encounter any issues or have suggestions for improvements, please don't hesitate to contribute to the GitHub repository.

--- a/docker/glab/Dockerfile
+++ b/docker/glab/Dockerfile
@@ -1,8 +1,21 @@
 ### VERSIONS METADATA ###
-ARG IMAGE_VERSION=0.1.0
-ARG ALPINE_VERSION=3.21.2
-ARG VAULT_VERSION=1.18.3
-ARG TF_VERSION=1.9.8
+ARG IMAGE_VERSION=1.0.1
+ARG ALPINE_VERSION=3.20
+ARG GO_VERSION=1.22.5
+ARG VAULT_VERSION=1.17.2
+### END VERSIONS METADATA ###
+
+
+# Build release-cli from source
+FROM golang:${GO_VERSION}-alpine${ALPINE_VERSION} AS realese-cli-builder
+
+# Install dependencies
+RUN apk --no-cache add ca-certificates make git && update-ca-certificates
+RUN git clone https://gitlab.com/gitlab-org/release-cli.git
+
+# Build binary
+WORKDIR /go/release-cli
+RUN make build
 
 
 # Download vault binary
@@ -25,24 +38,6 @@ RUN apk add --update --no-cache --virtual .deps --no-cache gnupg && \
     rm -f /tmp/${PRODUCT}_${VAULT_VERSION}_linux_amd64.zip ${PRODUCT}_${VAULT_VERSION}_SHA256SUMS ${VAULT_VERSION}/${PRODUCT}_${VAULT_VERSION}_SHA256SUMS.sig && \
     apk del .deps
 
-# Download terraform binary
-FROM alpine:${ALPINE_VERSION} AS terraform-builder
-
-ARG TF_VERSION
-ENV TF_VERSION=${TF_VERSION}
-ENV PRODUCT=terraform
-RUN apk add --update --virtual .deps --no-cache gnupg && \
-    cd /tmp && \
-    wget https://releases.hashicorp.com/${PRODUCT}/${TF_VERSION}/${PRODUCT}_${TF_VERSION}_linux_amd64.zip && \
-    wget https://releases.hashicorp.com/${PRODUCT}/${TF_VERSION}/${PRODUCT}_${TF_VERSION}_SHA256SUMS && \
-    wget https://releases.hashicorp.com/${PRODUCT}/${TF_VERSION}/${PRODUCT}_${TF_VERSION}_SHA256SUMS.sig && \
-    wget -qO- https://www.hashicorp.com/.well-known/pgp-key.txt | gpg --import && \
-    gpg --verify ${PRODUCT}_${TF_VERSION}_SHA256SUMS.sig ${PRODUCT}_${TF_VERSION}_SHA256SUMS && \
-    grep ${PRODUCT}_${TF_VERSION}_linux_amd64.zip ${PRODUCT}_${TF_VERSION}_SHA256SUMS | sha256sum -c && \
-    unzip /tmp/${PRODUCT}_${TF_VERSION}_linux_amd64.zip -d /tmp && \
-    mv /tmp/${PRODUCT} /usr/local/bin/${PRODUCT} && \
-    rm -f /tmp/${PRODUCT}_${TF_VERSION}_linux_amd64.zip ${PRODUCT}_${TF_VERSION}_SHA256SUMS ${TF_VERSION}/${PRODUCT}_${TF_VERSION}_SHA256SUMS.sig && \
-    apk del .deps
 
 # Build the final image
 FROM alpine:${ALPINE_VERSION}
@@ -57,9 +52,13 @@ LABEL org.opencontainers.image.source https://github.com/obervinov/images
 LABEL org.opencontainers.image.version ${IMAGE_VERSION}
 
 RUN apk -U upgrade && apk add --no-cache \
+    glab \
     curl \
     git \
-    bash
+    bash \
+    aws-cli \
+    helm
 
+COPY --from=realese-cli-builder /go/release-cli/bin/release-cli /usr/local/bin/release-cli
+COPY --from=realese-cli-builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=vault-builder /usr/local/bin/vault /usr/local/bin/vault
-COPY --from=terraform-builder /usr/local/bin/terraform /usr/local/bin/terraform


### PR DESCRIPTION
## v1.2.0 - 2025-01-22
### What's Changed
**Full Changelog**: https://github.com/obervinov/images/compare/v1.1.3...v1.2.0 by @obervinov in https://github.com/obervinov/images/pull/24
#### 🚀 Features
* Add `ghub` image for GitHub self-hosted runners
* Bump workflow version to `2.0.2`
#### 📚 Documentation
* https://github.com/obervinov/images/issues/4


