### PR TITLE
Release v1.3.0: Add support multi-arch build for `ghub` and `backup-tools` images

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -11,6 +11,6 @@ on:
 
 jobs:
   pr:
-    uses: obervinov/_templates/.github/workflows/pr.yaml@v2.0.2
+    uses: obervinov/_templates/.github/workflows/pr.yaml@v2.1.0
   images:
-    uses: obervinov/_templates/.github/workflows/images.yaml@v2.0.2
+    uses: obervinov/_templates/.github/workflows/images.yaml@v2.1.0

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -11,6 +11,6 @@ on:
 
 jobs:
   pr:
-    uses: obervinov/_templates/.github/workflows/pr.yaml@release/v2.1.0
+    uses: obervinov/_templates/.github/workflows/pr.yaml@v2.1.0
   images:
-    uses: obervinov/_templates/.github/workflows/images.yaml@release/v2.1.0
+    uses: obervinov/_templates/.github/workflows/images.yaml@v2.1.0

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -11,6 +11,6 @@ on:
 
 jobs:
   pr:
-    uses: obervinov/_templates/.github/workflows/pr.yaml@v2.1.0
+    uses: obervinov/_templates/.github/workflows/pr.yaml@release/v2.1.0
   images:
-    uses: obervinov/_templates/.github/workflows/images.yaml@v2.1.0
+    uses: obervinov/_templates/.github/workflows/images.yaml@release/v2.1.0

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,6 +10,6 @@ on:
 
 jobs:
   release:
-    uses: obervinov/_templates/.github/workflows/release.yaml@v2.0.2
+    uses: obervinov/_templates/.github/workflows/release.yaml@v2.1.0
   images:
-    uses: obervinov/_templates/.github/workflows/images.yaml@v2.0.2
+    uses: obervinov/_templates/.github/workflows/images.yaml@v2.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
 
+## v1.3.0 - 2025-01-23
+### What's Changed
+**Full Changelog**: https://github.com/obervinov/images/compare/v1.2.0...v1.3.0 by @obervinov in https://github.com/obervinov/images/pull/25
+#### 🚀 Features
+* Add support multi-arch build for `ghub` and `backup-tools` images
+* Bump workflow version to `2.1.0`
+
+
 ## v1.2.0 - 2025-01-22
 ### What's Changed
 **Full Changelog**: https://github.com/obervinov/images/compare/v1.1.3...v1.2.0 by @obervinov in https://github.com/obervinov/images/pull/24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
 
-## v1.3.0 - 2025-01-23
+## v1.3.0 - 2025-01-29
 ### What's Changed
 **Full Changelog**: https://github.com/obervinov/images/compare/v1.2.0...v1.3.0 by @obervinov in https://github.com/obervinov/images/pull/25
 #### 🚀 Features

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Docker Images Repository
 This repository contains Dockerfiles for building Docker images.
-[![CodeQL](https://github.com/obervinov/images/actions/workflows/github-code-scanning/codeql/badge.svg)](https://github.com/obervinov/images/actions/workflows/github-code-scanning/codeql)
+
 [![PR](https://github.com/obervinov/images/actions/workflows/pr.yaml/badge.svg?branch=main&event=pull_request)](https://github.com/obervinov/images/actions/workflows/pr.yaml)
 [![Release](https://github.com/obervinov/images/actions/workflows/release.yaml/badge.svg)](https://github.com/obervinov/images/actions/workflows/release.yaml)
 

--- a/docker/backup-tools/Dockerfile
+++ b/docker/backup-tools/Dockerfile
@@ -10,31 +10,36 @@ ARG VAULT_VERSION=1.17.2
 FROM alpine:${ALPINE_VERSION} AS vault-builder
 
 ARG VAULT_VERSION
+ARG TARGETARCH
 ENV VAULT_VERSION=${VAULT_VERSION}
 ENV PRODUCT=vault
+ENV TARGETARCH=${TARGETARCH}
  
 RUN apk add --update --no-cache --virtual .deps --no-cache gnupg && \
     cd /tmp && \
-    wget https://releases.hashicorp.com/${PRODUCT}/${VAULT_VERSION}/${PRODUCT}_${VAULT_VERSION}_linux_amd64.zip && \
+    wget https://releases.hashicorp.com/${PRODUCT}/${VAULT_VERSION}/${PRODUCT}_${VAULT_VERSION}_linux_${TARGETARCH}.zip && \
     wget https://releases.hashicorp.com/${PRODUCT}/${VAULT_VERSION}/${PRODUCT}_${VAULT_VERSION}_SHA256SUMS && \
     wget https://releases.hashicorp.com/${PRODUCT}/${VAULT_VERSION}/${PRODUCT}_${VAULT_VERSION}_SHA256SUMS.sig && \
     wget -qO- https://www.hashicorp.com/.well-known/pgp-key.txt | gpg --import && \
     gpg --verify ${PRODUCT}_${VAULT_VERSION}_SHA256SUMS.sig ${PRODUCT}_${VAULT_VERSION}_SHA256SUMS && \
-    grep ${PRODUCT}_${VAULT_VERSION}_linux_amd64.zip ${PRODUCT}_${VAULT_VERSION}_SHA256SUMS | sha256sum -c && \
-    unzip /tmp/${PRODUCT}_${VAULT_VERSION}_linux_amd64.zip -d /tmp && \
+    grep ${PRODUCT}_${VAULT_VERSION}_linux_${TARGETARCH}.zip ${PRODUCT}_${VAULT_VERSION}_SHA256SUMS | sha256sum -c && \
+    unzip /tmp/${PRODUCT}_${VAULT_VERSION}_linux_${TARGETARCH}.zip -d /tmp && \
     mv /tmp/${PRODUCT} /usr/local/bin/${PRODUCT} && \
-    rm -f /tmp/${PRODUCT}_${VAULT_VERSION}_linux_amd64.zip ${PRODUCT}_${VAULT_VERSION}_SHA256SUMS ${VAULT_VERSION}/${PRODUCT}_${VAULT_VERSION}_SHA256SUMS.sig && \
+    rm -f /tmp/${PRODUCT}_${VAULT_VERSION}_linux_${TARGETARCH}.zip ${PRODUCT}_${VAULT_VERSION}_SHA256SUMS ${VAULT_VERSION}/${PRODUCT}_${VAULT_VERSION}_SHA256SUMS.sig && \
     apk del .deps
 
 
 # Build rclone from source
 FROM golang:${GO_VERSION}-alpine${ALPINE_VERSION} AS rclone-builder
 
+ARG TARGETARCH
+ENV TARGETARCH=${TARGETARCH}
+
 RUN apk --no-cache add ca-certificates make git && update-ca-certificates
 RUN apk --no-cache add curl unzip
-RUN curl -O https://downloads.rclone.org/rclone-current-linux-amd64.zip && \
-    unzip rclone-current-linux-amd64.zip && \
-    cd rclone-*-linux-amd64 && \
+RUN curl -O https://downloads.rclone.org/rclone-current-linux-${TARGETARCH}.zip && \
+    unzip rclone-current-linux-${TARGETARCH}.zip && \
+    cd rclone-*-linux-${TARGETARCH} && \
     cp rclone /usr/local/bin/ && \
     chown root:root /usr/local/bin/rclone && \
     chmod 755 /usr/local/bin/rclone && \

--- a/docker/ghub/Dockerfile
+++ b/docker/ghub/Dockerfile
@@ -3,45 +3,51 @@ ARG IMAGE_VERSION=0.1.0
 ARG ALPINE_VERSION=3.21.2
 ARG VAULT_VERSION=1.18.3
 ARG TF_VERSION=1.9.8
+ARG TARGETARCH
 
 
 # Download vault binary
 FROM alpine:${ALPINE_VERSION} AS vault-builder
 
 ARG VAULT_VERSION
+ARG TARGETARCH
 ENV VAULT_VERSION=${VAULT_VERSION}
 ENV PRODUCT=vault
- 
+ENV TARGETARCH=${TARGETARCH}
+
 RUN apk add --update --no-cache --virtual .deps --no-cache gnupg && \
     cd /tmp && \
-    wget https://releases.hashicorp.com/${PRODUCT}/${VAULT_VERSION}/${PRODUCT}_${VAULT_VERSION}_linux_amd64.zip && \
+    wget https://releases.hashicorp.com/${PRODUCT}/${VAULT_VERSION}/${PRODUCT}_${VAULT_VERSION}_linux_${TARGETARCH}.zip && \
     wget https://releases.hashicorp.com/${PRODUCT}/${VAULT_VERSION}/${PRODUCT}_${VAULT_VERSION}_SHA256SUMS && \
     wget https://releases.hashicorp.com/${PRODUCT}/${VAULT_VERSION}/${PRODUCT}_${VAULT_VERSION}_SHA256SUMS.sig && \
     wget -qO- https://www.hashicorp.com/.well-known/pgp-key.txt | gpg --import && \
     gpg --verify ${PRODUCT}_${VAULT_VERSION}_SHA256SUMS.sig ${PRODUCT}_${VAULT_VERSION}_SHA256SUMS && \
-    grep ${PRODUCT}_${VAULT_VERSION}_linux_amd64.zip ${PRODUCT}_${VAULT_VERSION}_SHA256SUMS | sha256sum -c && \
-    unzip /tmp/${PRODUCT}_${VAULT_VERSION}_linux_amd64.zip -d /tmp && \
+    grep ${PRODUCT}_${VAULT_VERSION}_linux_${TARGETARCH}.zip ${PRODUCT}_${VAULT_VERSION}_SHA256SUMS | sha256sum -c && \
+    unzip /tmp/${PRODUCT}_${VAULT_VERSION}_linux_${TARGETARCH}.zip -d /tmp && \
     mv /tmp/${PRODUCT} /usr/local/bin/${PRODUCT} && \
-    rm -f /tmp/${PRODUCT}_${VAULT_VERSION}_linux_amd64.zip ${PRODUCT}_${VAULT_VERSION}_SHA256SUMS ${VAULT_VERSION}/${PRODUCT}_${VAULT_VERSION}_SHA256SUMS.sig && \
+    rm -f /tmp/${PRODUCT}_${VAULT_VERSION}_linux_${TARGETARCH}.zip ${PRODUCT}_${VAULT_VERSION}_SHA256SUMS ${VAULT_VERSION}/${PRODUCT}_${VAULT_VERSION}_SHA256SUMS.sig && \
     apk del .deps
 
 # Download terraform binary
 FROM alpine:${ALPINE_VERSION} AS terraform-builder
 
 ARG TF_VERSION
+ARG TARGETARCH
 ENV TF_VERSION=${TF_VERSION}
 ENV PRODUCT=terraform
+ENV TARGETARCH=${TARGETARCH}
+
 RUN apk add --update --virtual .deps --no-cache gnupg && \
     cd /tmp && \
-    wget https://releases.hashicorp.com/${PRODUCT}/${TF_VERSION}/${PRODUCT}_${TF_VERSION}_linux_amd64.zip && \
+    wget https://releases.hashicorp.com/${PRODUCT}/${TF_VERSION}/${PRODUCT}_${TF_VERSION}_linux_${TARGETARCH}.zip && \
     wget https://releases.hashicorp.com/${PRODUCT}/${TF_VERSION}/${PRODUCT}_${TF_VERSION}_SHA256SUMS && \
     wget https://releases.hashicorp.com/${PRODUCT}/${TF_VERSION}/${PRODUCT}_${TF_VERSION}_SHA256SUMS.sig && \
     wget -qO- https://www.hashicorp.com/.well-known/pgp-key.txt | gpg --import && \
     gpg --verify ${PRODUCT}_${TF_VERSION}_SHA256SUMS.sig ${PRODUCT}_${TF_VERSION}_SHA256SUMS && \
-    grep ${PRODUCT}_${TF_VERSION}_linux_amd64.zip ${PRODUCT}_${TF_VERSION}_SHA256SUMS | sha256sum -c && \
-    unzip /tmp/${PRODUCT}_${TF_VERSION}_linux_amd64.zip -d /tmp && \
+    grep ${PRODUCT}_${TF_VERSION}_linux_${TARGETARCH}.zip ${PRODUCT}_${TF_VERSION}_SHA256SUMS | sha256sum -c && \
+    unzip /tmp/${PRODUCT}_${TF_VERSION}_linux_${TARGETARCH}.zip -d /tmp && \
     mv /tmp/${PRODUCT} /usr/local/bin/${PRODUCT} && \
-    rm -f /tmp/${PRODUCT}_${TF_VERSION}_linux_amd64.zip ${PRODUCT}_${TF_VERSION}_SHA256SUMS ${TF_VERSION}/${PRODUCT}_${TF_VERSION}_SHA256SUMS.sig && \
+    rm -f /tmp/${PRODUCT}_${TF_VERSION}_linux_${TARGETARCH}.zip ${PRODUCT}_${TF_VERSION}_SHA256SUMS ${TF_VERSION}/${PRODUCT}_${TF_VERSION}_SHA256SUMS.sig && \
     apk del .deps
 
 # Build the final image


### PR DESCRIPTION
## v1.3.0 - 2025-01-29
### What's Changed
**Full Changelog**: https://github.com/obervinov/images/compare/v1.2.0...v1.3.0 by @obervinov in https://github.com/obervinov/images/pull/25
#### 🚀 Features
* Add support multi-arch build for `ghub` and `backup-tools` images
* Bump workflow version to `2.1.0`


