### PR TITLE
Release v1.4.2: Update Caddy and JupyterHub images

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,7 +21,7 @@ jobs:
           - "docker/certbot"
           - "docker/debug"
           - "docker/ghub"
-          - "docker/glab"
+          #- "docker/glab"
           - "docker/gradle"
           - "docker/jupyterhub"
           - "docker/python"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
 
+## v1.4.2 - 2025-03-25
+### What's Changed
+**Full Changelog**: https://github.com/obervinov/images/compare/v1.4.1...v1.4.2 by @obervinov in https://github.com/obervinov/images/pull/30
+#### 🚀 Features
+* Bump dependencies in the `Caddy` image
+* Bump dependencies in the `JupyterHub` image
+* Add geoip module to the `Caddy` image
+#### 🐛 Bug Fixes
+* Small improvements in the `JupyterHub` image
+
+
 ## v1.4.1 - 2025-02-18
 ### What's Changed
 **Full Changelog**: https://github.com/obervinov/images/compare/v1.4.0...v1.4.1 by @obervinov in https://github.com/obervinov/images/pull/29

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 **Full Changelog**: https://github.com/obervinov/images/compare/v1.4.1...v1.4.2 by @obervinov in https://github.com/obervinov/images/pull/30
 #### 🚀 Features
 * Bump dependencies in the `Caddy` image
-* Bump dependencies in the `JupyterHub` image
 * Add geoip module to the `Caddy` image
 #### 🐛 Bug Fixes
 * Small improvements in the `JupyterHub` image

--- a/docker/caddy/Dockerfile
+++ b/docker/caddy/Dockerfile
@@ -1,13 +1,12 @@
 ### VERSIONS METADATA ###
 ARG IMAGE_VERSION=2.9.1
-ARG ALPINE_VERSION=3.21.3
-ARG GO_VERSION=1.24.1
+ARG GOLANG_VERSION=1.24.1-alpine3.21
 ARG CADDY_VERSION=2.9.1
 ### END VERSIONS METADATA ###
 
 
 # Build binary with plugins
-FROM golang:${GO_VERSION}-alpine${ALPINE_VERSION} AS builder
+FROM golang:${GOLANG_VERSION} AS builder
 
 WORKDIR /tmp
 RUN apk --no-cache add ca-certificates make git && update-ca-certificates

--- a/docker/caddy/Dockerfile
+++ b/docker/caddy/Dockerfile
@@ -1,8 +1,8 @@
 ### VERSIONS METADATA ###
-ARG IMAGE_VERSION=2.8.4
-ARG ALPINE_VERSION=3.20
-ARG GO_VERSION=1.22.5
-ARG CADDY_VERSION=2.8.4
+ARG IMAGE_VERSION=2.9.1
+ARG ALPINE_VERSION=3.21.3
+ARG GO_VERSION=1.24.1
+ARG CADDY_VERSION=2.9.1
 ### END VERSIONS METADATA ###
 
 
@@ -18,6 +18,7 @@ RUN go install github.com/caddyserver/xcaddy/cmd/xcaddy@latest
 RUN xcaddy build \
     --with github.com/caddy-dns/digitalocean@master \
     --with github.com/mholt/caddy-l4 \
+    --with github.com/shift72/caddy-geo-ip \
     --output /usr/bin/caddy
 
 

--- a/docker/caddy/README.md
+++ b/docker/caddy/README.md
@@ -1,6 +1,9 @@
-# Caddy Docker Image with DNS Plugin
+# Caddy Docker Image with Additional Plugins
+- DigitalOcean DNS plugin support
+- L4 Load Balancing
+- GeoIP
 
-This Docker image is designed to provide a custom Caddy server with DNS plugin support. It includes the necessary plugins for DigitalOcean DNS integration.
+This Docker image is designed to provide a custom Caddy server with additional plugins.
 
 ## Build Process
 
@@ -10,34 +13,12 @@ This Docker image is built in two stages:
 
 2. **Build Clear Image**: This stage utilizes the official `caddy` Docker image as a base. It copies the previously built binary into the final image, ensuring that the Caddy server is ready with the configured plugins.
 
-## Usage
-
-You can use this Docker image by pulling it from the Docker Hub or by building it locally using the provided Dockerfile.
-
-### Pull from Docker Hub
-
-```bash
-docker pull <your-dockerhub-username>/caddy-dns
-```
-
-### Build Locally
-
-```bash
-docker build -t caddy-dns .
-```
-
-### Run Container
-
-```bash
-docker run -d -p 80:80 -p 443:443 caddy-dns
-```
-
 ## Additional Information
 
 - **Image Description**: This image contains a Caddy server with DNS plugin support for DigitalOcean.
 - **Documentation**: [GitHub Repository](https://github.com/obervinov/images/docker/caddy/README.md)
 - **Author**: [obervinov](https://github.com/obervinov)
 - **Source Code**: [GitHub Repository](https://github.com/obervinov/images/docker/caddy/Dockerfile)
-- **Version**: 2.7.5-alpine
+- **Version**: 2.9.1-alpine
 
 Feel free to customize this image according to your specific requirements and environment. If you encounter any issues or have suggestions for improvements, please don't hesitate to contribute to the GitHub repository.

--- a/docker/jupyterhub/Dockerfile
+++ b/docker/jupyterhub/Dockerfile
@@ -1,8 +1,8 @@
 FROM quay.io/jupyterhub/k8s-singleuser-sample:4.1.0
 
-ARG IMAGE_VERSION=1.0.1
+ARG IMAGE_VERSION=1.0.2
 
-LABEL org.opencontainers.image.description "This image contains utilities for automating work with gitlab"
+LABEL org.opencontainers.image.description "This image contains utilities for automating work with JupiterHub"
 LABEL org.opencontainers.image.url https://github.com/obervinov/images/docker/jupyterhub
 LABEL org.opencontainers.image.documentation https://github.com/obervinov/images/docker/jupyterhub/README.md
 LABEL org.opencontainers.image.authors https://github.com/obervinov
@@ -40,6 +40,8 @@ RUN apt-get update && apt-get upgrade -y && \
         libglib2.0-0 \
         && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
+RUN mkdir -p /.git-credentials-cache && chmod 600 /.git-credentials-cache
+RUN git config --global credential.helper 'cache --timeout=3600000'
 
 USER jovyan
 ENV VENV_PATH=/home/jovyan/.venv


### PR DESCRIPTION
## v1.4.2 - 2025-03-25
### What's Changed
**Full Changelog**: https://github.com/obervinov/images/compare/v1.4.1...v1.4.2 by @obervinov in https://github.com/obervinov/images/pull/30
#### 🚀 Features
* Bump dependencies in the `Caddy` image
* Add geoip module to the `Caddy` image
#### 🐛 Bug Fixes
* Small improvements in the `JupyterHub` image


