### PR TITLE
Release v1.4.3: Add Trivy UI image

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,6 +26,7 @@ jobs:
           - "docker/jupyterhub"
           - "docker/python"
           - "docker/vault"
+          - "docker/trivy-ui"
 
     steps:
       - name: Checkout code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
 
+## v1.4.3 - 2025-03-27
+### What's Changed
+**Full Changelog**: https://github.com/obervinov/images/compare/v1.4.2...v1.4.3 by @obervinov in https://github.com/obervinov/images/pull/31
+#### 🚀 Features
+* Add new image `trivy-ui` for Trivy web UI
+
+
 ## v1.4.2 - 2025-03-25
 ### What's Changed
 **Full Changelog**: https://github.com/obervinov/images/compare/v1.4.1...v1.4.2 by @obervinov in https://github.com/obervinov/images/pull/30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
 
-## v1.4.3 - 2025-03-27
+## v1.4.3 - 2025-03-28
 ### What's Changed
 **Full Changelog**: https://github.com/obervinov/images/compare/v1.4.2...v1.4.3 by @obervinov in https://github.com/obervinov/images/pull/31
 #### 🚀 Features

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ This repository contains Dockerfiles for building Docker images.
 | vault         | Docker image for HashiCorp Vault.                   | [README](docker/vault/README.md)        | [Manifest](docker/vault/Dockerfile)        |
 | backup-tools  | Docker image for backup tools.                      | [README](docker/backup-tools/README.md) | [Manifest](docker/backup-tools/Dockerfile) |
 | jupyterhub    | Docker image for JupyterHub user servers.           | [README](docker/jupyterhub/README.md)   | [Manifest](docker/jupyterhub/Dockerfile)   |
+| trivy-ui     | Docker image for Trivy web UI.                      | [README](docker/trivy-ui/README.md)     | [Manifest](docker/trivy-ui/Dockerfile)     |
 
 Each directory under `docker/` corresponds to a specific Docker image. Navigate to each directory to view the respective Dockerfile and README for further instructions.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,8 +6,8 @@ Versions supported to fix vulnerabilities
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 1.0.x   | :white_check_mark: |
+| 1.x.x   | :white_check_mark: |
 
 ## Reporting a Vulnerability
 
-In order to inform me about the vulnerability, write the details to the mail `github.obervinov@proton.me`
+In order to inform me about the vulnerability, please create an issue with the label "security" and I will try to fix it as soon as possible.

--- a/docker/trivy-ui/Dockerfile
+++ b/docker/trivy-ui/Dockerfile
@@ -9,7 +9,7 @@ RUN apt update && apt install -y curl git \
     && apt install -y nodejs \
     && npm install -g npm@latest \
     && rm -rf /var/lib/apt/lists/*
-RUN git clone "https://github.com/obervinov/trivy-ui.git" && git checkout feature/k8s-in-cluster-support
+RUN git clone "https://github.com/obervinov/trivy-ui.git" && cd trivy-ui && git checkout feature/k8s-in-cluster-support
 RUN cd trivy-ui/go-server && go build -o go-server
 RUN cd trivy-ui/trivy-dashboard && npm install && npm run build
 

--- a/docker/trivy-ui/Dockerfile
+++ b/docker/trivy-ui/Dockerfile
@@ -9,9 +9,9 @@ RUN apt update && apt install -y curl git \
     && apt install -y nodejs \
     && npm install -g npm@latest \
     && rm -rf /var/lib/apt/lists/*
-RUN git clone https://github.com/llocustbaby/trivy-ui.git && mv trivy-ui/* .
-RUN cd go-server && go build -o go-server
-RUN cd trivy-dashboard && npm install && npm run build
+RUN git clone "https://github.com/llocustbaby/trivy-ui.git"
+RUN cd trivy-ui/go-server && go build -o go-server
+RUN cd trivy-ui/trivy-dashboard && npm install && npm run build
 
 
 FROM debian:bullseye-slim
@@ -19,8 +19,8 @@ FROM debian:bullseye-slim
 ARG IMAGE_VERSION
 
 WORKDIR /app
-COPY --from=build /app/go-server/go-server /app/go-server
-COPY --from=build /app/trivy-dashboard/dist /app/trivy-dashboard/dist
+COPY --from=build /app/trivy-ui/go-server/go-server /app/go-server
+COPY --from=build /app/trivy-ui/trivy-dashboard/dist /app/trivy-dashboard/dist
 RUN apt update && apt install -y ca-certificates && rm -rf /var/lib/apt/lists/*
 
 LABEL org.opencontainers.image.description "This image contains Backend Trivy UI"

--- a/docker/trivy-ui/Dockerfile
+++ b/docker/trivy-ui/Dockerfile
@@ -23,7 +23,7 @@ COPY --from=build /app/trivy-ui/go-server/go-server /app/go-server
 COPY --from=build /app/trivy-ui/trivy-dashboard/dist /app/trivy-dashboard/dist
 RUN apt update && apt install -y ca-certificates && rm -rf /var/lib/apt/lists/*
 
-LABEL org.opencontainers.image.description "This image contains Backend Trivy UI"
+LABEL org.opencontainers.image.description "This image contains Trivy UI"
 LABEL org.opencontainers.image.url "https://github.com/llocustbaby/trivy-ui"
 LABEL org.opencontainers.image.documentation "https://github.com/locustbaby/trivy-ui/blob/main/README.md"
 LABEL org.opencontainers.image.authors "https://github.com/locustbaby"

--- a/docker/trivy-ui/Dockerfile
+++ b/docker/trivy-ui/Dockerfile
@@ -1,0 +1,29 @@
+ARG NODE_VERSION=23.10.0-alpine3.21
+ARG GOLANG_VERSION=1.24.1-bullseye
+
+FROM golang:${GOLANG_VERSION} AS build
+WORKDIR /app
+RUN apt update && apt install -y curl git \
+    && curl -fsSL https://deb.nodesource.com/setup_23.x | bash - \
+    && apt install -y nodejs \
+    && npm install -g npm@latest \
+    && rm -rf /var/lib/apt/lists/*
+RUN git clone https://github.com/llocustbaby/trivy-ui.git && mv trivy-ui/* .
+RUN cd go-server && go build -o go-server
+RUN cd trivy-dashboard && npm install && npm run build
+
+
+FROM debian:bullseye-slim
+WORKDIR /app
+COPY --from=build /app/go-server/go-server /app/go-server
+COPY --from=build /app/trivy-dashboard/dist /app/trivy-dashboard/dist
+RUN apt update && apt install -y ca-certificates && rm -rf /var/lib/apt/lists/*
+
+LABEL org.opencontainers.image.description "This image contains Backend Trivy UI"
+LABEL org.opencontainers.image.url "https://github.com/llocustbaby/trivy-ui"
+LABEL org.opencontainers.image.documentation "https://github.com/locustbaby/trivy-ui/blob/main/README.md"
+LABEL org.opencontainers.image.authors "https://github.com/locustbaby"
+LABEL org.opencontainers.image.source "https://github.com/locustbaby/trivy-ui"
+
+CMD ["/app/go-server"]
+EXPOSE 8080

--- a/docker/trivy-ui/Dockerfile
+++ b/docker/trivy-ui/Dockerfile
@@ -9,7 +9,7 @@ RUN apt update && apt install -y curl git \
     && apt install -y nodejs \
     && npm install -g npm@latest \
     && rm -rf /var/lib/apt/lists/*
-RUN git clone "https://github.com/locustbaby/trivy-ui.git"
+RUN git clone "https://github.com/obervinov/trivy-ui.git" && git checkout feature/k8s-in-cluster-support
 RUN cd trivy-ui/go-server && go build -o go-server
 RUN cd trivy-ui/trivy-dashboard && npm install && npm run build
 

--- a/docker/trivy-ui/Dockerfile
+++ b/docker/trivy-ui/Dockerfile
@@ -1,5 +1,6 @@
 ARG NODE_VERSION=23.10.0-alpine3.21
 ARG GOLANG_VERSION=1.24.1-bullseye
+ARG IMAGE_VERSION=0.1.0
 
 FROM golang:${GOLANG_VERSION} AS build
 WORKDIR /app
@@ -14,6 +15,9 @@ RUN cd trivy-dashboard && npm install && npm run build
 
 
 FROM debian:bullseye-slim
+
+ARG IMAGE_VERSION
+
 WORKDIR /app
 COPY --from=build /app/go-server/go-server /app/go-server
 COPY --from=build /app/trivy-dashboard/dist /app/trivy-dashboard/dist
@@ -24,6 +28,7 @@ LABEL org.opencontainers.image.url "https://github.com/llocustbaby/trivy-ui"
 LABEL org.opencontainers.image.documentation "https://github.com/locustbaby/trivy-ui/blob/main/README.md"
 LABEL org.opencontainers.image.authors "https://github.com/locustbaby"
 LABEL org.opencontainers.image.source "https://github.com/locustbaby/trivy-ui"
+LABEL org.opencontainers.image.version ${IMAGE_VERSION}
 
 CMD ["/app/go-server"]
 EXPOSE 8080

--- a/docker/trivy-ui/Dockerfile
+++ b/docker/trivy-ui/Dockerfile
@@ -9,7 +9,7 @@ RUN apt update && apt install -y curl git \
     && apt install -y nodejs \
     && npm install -g npm@latest \
     && rm -rf /var/lib/apt/lists/*
-RUN git clone "https://github.com/llocustbaby/trivy-ui.git"
+RUN git clone "https://github.com/locustbaby/trivy-ui.git"
 RUN cd trivy-ui/go-server && go build -o go-server
 RUN cd trivy-ui/trivy-dashboard && npm install && npm run build
 

--- a/docker/trivy-ui/README.md
+++ b/docker/trivy-ui/README.md
@@ -1,0 +1,24 @@
+# Caddy Docker Image with Additional Plugins
+- DigitalOcean DNS plugin support
+- L4 Load Balancing
+- GeoIP
+
+This Docker image is designed to provide a custom Caddy server with additional plugins.
+
+## Build Process
+
+This Docker image is built in two stages:
+
+1. **Build Binary with Plugins**: This stage fetches the Caddy source code from the official GitHub repository and compiles it with the required plugins. The `xcaddy` tool is used to facilitate this process. The resulting binary is then stored in a temporary location.
+
+2. **Build Clear Image**: This stage utilizes the official `caddy` Docker image as a base. It copies the previously built binary into the final image, ensuring that the Caddy server is ready with the configured plugins.
+
+## Additional Information
+
+- **Image Description**: This image contains a Caddy server with DNS plugin support for DigitalOcean.
+- **Documentation**: [GitHub Repository](https://github.com/obervinov/images/docker/caddy/README.md)
+- **Author**: [obervinov](https://github.com/obervinov)
+- **Source Code**: [GitHub Repository](https://github.com/obervinov/images/docker/caddy/Dockerfile)
+- **Version**: 2.9.1-alpine
+
+Feel free to customize this image according to your specific requirements and environment. If you encounter any issues or have suggestions for improvements, please don't hesitate to contribute to the GitHub repository.

--- a/docker/trivy-ui/README.md
+++ b/docker/trivy-ui/README.md
@@ -1,6 +1,6 @@
 # Trivy UI Docker Image for multi-architecture
 
 - **Image Description**: This image contains a Trivy UI application that provides a web-based interface for Trivy, a comprehensive and easy-to-use vulnerability scanner for container images. The Trivy UI application allows users to scan container images for vulnerabilities and view the results in a user-friendly web interface. The application is built using the Trivy API and provides a simple and intuitive way to scan container images for vulnerabilities.
-- **Documentation**: [GitHub Repository](https://github.com/llocustbaby/trivy-ui/README.md)
+- **Documentation**: [GitHub Repository](https://github.com/locustbaby/trivy-ui/README.md)
 - **Author**: [locustbaby](https://github.com/locustbaby)
 - **Source Code**: [GitHub Repository](https://github.com/locustbaby/trivy-ui)

--- a/docker/trivy-ui/README.md
+++ b/docker/trivy-ui/README.md
@@ -1,24 +1,6 @@
-# Caddy Docker Image with Additional Plugins
-- DigitalOcean DNS plugin support
-- L4 Load Balancing
-- GeoIP
+# Trivy UI Docker Image for multi-architecture
 
-This Docker image is designed to provide a custom Caddy server with additional plugins.
-
-## Build Process
-
-This Docker image is built in two stages:
-
-1. **Build Binary with Plugins**: This stage fetches the Caddy source code from the official GitHub repository and compiles it with the required plugins. The `xcaddy` tool is used to facilitate this process. The resulting binary is then stored in a temporary location.
-
-2. **Build Clear Image**: This stage utilizes the official `caddy` Docker image as a base. It copies the previously built binary into the final image, ensuring that the Caddy server is ready with the configured plugins.
-
-## Additional Information
-
-- **Image Description**: This image contains a Caddy server with DNS plugin support for DigitalOcean.
-- **Documentation**: [GitHub Repository](https://github.com/obervinov/images/docker/caddy/README.md)
-- **Author**: [obervinov](https://github.com/obervinov)
-- **Source Code**: [GitHub Repository](https://github.com/obervinov/images/docker/caddy/Dockerfile)
-- **Version**: 2.9.1-alpine
-
-Feel free to customize this image according to your specific requirements and environment. If you encounter any issues or have suggestions for improvements, please don't hesitate to contribute to the GitHub repository.
+- **Image Description**: This image contains a Trivy UI application that provides a web-based interface for Trivy, a comprehensive and easy-to-use vulnerability scanner for container images. The Trivy UI application allows users to scan container images for vulnerabilities and view the results in a user-friendly web interface. The application is built using the Trivy API and provides a simple and intuitive way to scan container images for vulnerabilities.
+- **Documentation**: [GitHub Repository](https://github.com/llocustbaby/trivy-ui/README.md)
+- **Author**: [locustbaby](https://github.com/locustbaby)
+- **Source Code**: [GitHub Repository](https://github.com/locustbaby/trivy-ui)


### PR DESCRIPTION
## v1.4.3 - 2025-03-28
### What's Changed
**Full Changelog**: https://github.com/obervinov/images/compare/v1.4.2...v1.4.3 by @obervinov in https://github.com/obervinov/images/pull/31
#### 🚀 Features
* Add new image `trivy-ui` for Trivy web UI


