### PR TITLE
Release v1.4.4: Add Smartctl Exporter image for multiarch systems

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,6 +27,7 @@ jobs:
           - "docker/python"
           - "docker/vault"
           - "docker/trivy-ui"
+          - "docker/smartctl-exporter"
 
     steps:
       - name: Checkout code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
 
+## v1.4.4 - 2025-04-15
+### What's Changed
+**Full Changelog**: https://github.com/obervinov/images/compare/v1.4.3...v1.4.4 by @obervinov in https://github.com/obervinov/images/pull/32
+#### 🚀 Features
+* Add new image `smartctl-exporter` for smartctl exporter
+* Switch source repository for `trivy-ui` image to `locustbaby/trivy-ui`
+
+
 ## v1.4.3 - 2025-03-28
 ### What's Changed
 **Full Changelog**: https://github.com/obervinov/images/compare/v1.4.2...v1.4.3 by @obervinov in https://github.com/obervinov/images/pull/31

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ This repository contains Dockerfiles for building Docker images.
 | backup-tools  | Docker image for backup tools.                      | [README](docker/backup-tools/README.md) | [Manifest](docker/backup-tools/Dockerfile) |
 | jupyterhub    | Docker image for JupyterHub user servers.           | [README](docker/jupyterhub/README.md)   | [Manifest](docker/jupyterhub/Dockerfile)   |
 | trivy-ui     | Docker image for Trivy web UI.                      | [README](docker/trivy-ui/README.md)     | [Manifest](docker/trivy-ui/Dockerfile)     |
+| smartctl-exporter | Docker image for smartctl-exporter.               | [README](docker/smartctl-exporter/README.md) | [Manifest](docker/smartctl-exporter/Dockerfile) |
 
 Each directory under `docker/` corresponds to a specific Docker image. Navigate to each directory to view the respective Dockerfile and README for further instructions.
 

--- a/docker/smartctl-exporter/Dockerfile
+++ b/docker/smartctl-exporter/Dockerfile
@@ -13,7 +13,7 @@ RUN git clone "https://github.com/prometheus-community/smartctl_exporter.git" /b
 FROM alpine:${ALPINE_VERSION}
 ARG IMAGE_VERSION
 
-RUN apk add --no-cache ca-certificates && apk upgrade --no-cache && rm -rf /var/cache/apk/*
+RUN apk add --no-cache ca-certificates smartmontools && apk upgrade --no-cache && rm -rf /var/cache/apk/*
 COPY --from=build /build/smartctl_exporter /bin/smartctl_exporter
 
 LABEL org.opencontainers.image.description "This image contains Smartctl Exporter"

--- a/docker/smartctl-exporter/Dockerfile
+++ b/docker/smartctl-exporter/Dockerfile
@@ -1,0 +1,26 @@
+ARG GOLANG_VERSION=1.24.1-bullseye
+ARG ALPINE_VERSION=3.21.3
+ARG IMAGE_VERSION=0.13.0
+
+FROM golang:${GOLANG_VERSION} AS build
+WORKDIR /build
+RUN apt update && apt install -y curl git && rm -rf /var/lib/apt/lists/*
+RUN git clone "https://github.com/prometheus-community/smartctl_exporter.git" && cd smartctl_exporter && go build -o smartctl_exporter
+
+
+FROM alpine:${ALPINE_VERSION}
+ARG IMAGE_VERSION
+
+RUN apt update && apt install -y ca-certificates && rm -rf /var/lib/apt/lists/*
+COPY --from=build /build/smartctl_exporter/smartctl_exporter /bin/smartctl_exporter
+
+LABEL org.opencontainers.image.description "This image contains Smartctl Exporter"
+LABEL org.opencontainers.image.url "https://github.com/prometheus-community/smartctl_exporter"
+LABEL org.opencontainers.image.documentation "https://github.com/prometheus-community/smartctl_exporter/blob/master/README.md"
+LABEL org.opencontainers.image.authors "https://github.com/obervinov"
+LABEL org.opencontainers.image.source "https://github.com/prometheus-community/smartctl_exporter"
+LABEL org.opencontainers.image.version ${IMAGE_VERSION}
+
+EXPOSE      9633
+USER        nobody
+ENTRYPOINT  [ "/bin/smartctl_exporter" ]

--- a/docker/smartctl-exporter/Dockerfile
+++ b/docker/smartctl-exporter/Dockerfile
@@ -11,7 +11,7 @@ RUN git clone "https://github.com/prometheus-community/smartctl_exporter.git" &&
 FROM alpine:${ALPINE_VERSION}
 ARG IMAGE_VERSION
 
-RUN apt update && apt install -y ca-certificates && rm -rf /var/lib/apt/lists/*
+RUN apk add --no-cache ca-certificates && apk upgrade --no-cache && rm -rf /var/cache/apk/*
 COPY --from=build /build/smartctl_exporter/smartctl_exporter /bin/smartctl_exporter
 
 LABEL org.opencontainers.image.description "This image contains Smartctl Exporter"

--- a/docker/smartctl-exporter/Dockerfile
+++ b/docker/smartctl-exporter/Dockerfile
@@ -2,17 +2,19 @@ ARG GOLANG_VERSION=1.24.1-bullseye
 ARG ALPINE_VERSION=3.21.3
 ARG IMAGE_VERSION=0.13.0
 
-FROM golang:${GOLANG_VERSION} AS build
+FROM alpine:${ALPINE_VERSION} as build
 WORKDIR /build
-RUN apt update && apt install -y curl git && rm -rf /var/lib/apt/lists/*
-RUN git clone "https://github.com/prometheus-community/smartctl_exporter.git" && cd smartctl_exporter && go build -o smartctl_exporter
+RUN apk add --no-cache --update go git build-base
+RUN git clone "https://github.com/prometheus-community/smartctl_exporter.git" /build && \
+    go build -o smartctl_exporter && chmod +x smartctl_exporter && \
+    /build/smartctl_exporter --help
 
 
 FROM alpine:${ALPINE_VERSION}
 ARG IMAGE_VERSION
 
 RUN apk add --no-cache ca-certificates && apk upgrade --no-cache && rm -rf /var/cache/apk/*
-COPY --from=build /build/smartctl_exporter/smartctl_exporter /bin/smartctl_exporter
+COPY --from=build /build/smartctl_exporter /bin/smartctl_exporter
 
 LABEL org.opencontainers.image.description "This image contains Smartctl Exporter"
 LABEL org.opencontainers.image.url "https://github.com/prometheus-community/smartctl_exporter"

--- a/docker/smartctl-exporter/README.md
+++ b/docker/smartctl-exporter/README.md
@@ -1,0 +1,6 @@
+# Smartctl Exporter Docker Image for multi-architecture
+
+- **Image Description**: This image contains a Smartctl Exporter application that provides a monitoring solution for hard drives and SSDs. The Smartctl Exporter application uses the smartctl command-line utility to gather SMART data from storage devices and exposes it in a format that can be consumed by Prometheus. This allows users to monitor the health and performance of their storage devices in real-time.
+- **Documentation**: [GitHub Repository](https://github.com/prometheus-community/smartctl_exporter/tree/master/README.md)
+- **Author**: [locustbaby](https://github.com/prometheus-community)
+- **Source Code**: [GitHub Repository](https://github.com/prometheus-community/smartctl_exporter)

--- a/docker/smartctl-exporter/README.md
+++ b/docker/smartctl-exporter/README.md
@@ -2,5 +2,5 @@
 
 - **Image Description**: This image contains a Smartctl Exporter application that provides a monitoring solution for hard drives and SSDs. The Smartctl Exporter application uses the smartctl command-line utility to gather SMART data from storage devices and exposes it in a format that can be consumed by Prometheus. This allows users to monitor the health and performance of their storage devices in real-time.
 - **Documentation**: [GitHub Repository](https://github.com/prometheus-community/smartctl_exporter/tree/master/README.md)
-- **Author**: [locustbaby](https://github.com/prometheus-community)
+- **Author**: [prometheus-community](https://github.com/prometheus-community)
 - **Source Code**: [GitHub Repository](https://github.com/prometheus-community/smartctl_exporter)

--- a/docker/trivy-ui/Dockerfile
+++ b/docker/trivy-ui/Dockerfile
@@ -1,6 +1,6 @@
 ARG NODE_VERSION=23.10.0-alpine3.21
 ARG GOLANG_VERSION=1.24.1-bullseye
-ARG IMAGE_VERSION=0.1.0
+ARG IMAGE_VERSION=0.1.1
 
 FROM golang:${GOLANG_VERSION} AS build
 WORKDIR /app
@@ -9,7 +9,7 @@ RUN apt update && apt install -y curl git \
     && apt install -y nodejs \
     && npm install -g npm@latest \
     && rm -rf /var/lib/apt/lists/*
-RUN git clone "https://github.com/obervinov/trivy-ui.git" && cd trivy-ui && git checkout feature/k8s-in-cluster-support
+RUN git clone "https://github.com/locustbaby/trivy-ui.git" && cd trivy-ui
 RUN cd trivy-ui/go-server && go build -o go-server
 RUN cd trivy-ui/trivy-dashboard && npm install && npm run build
 
@@ -26,7 +26,7 @@ RUN apt update && apt install -y ca-certificates && rm -rf /var/lib/apt/lists/*
 LABEL org.opencontainers.image.description "This image contains Trivy UI"
 LABEL org.opencontainers.image.url "https://github.com/llocustbaby/trivy-ui"
 LABEL org.opencontainers.image.documentation "https://github.com/locustbaby/trivy-ui/blob/main/README.md"
-LABEL org.opencontainers.image.authors "https://github.com/locustbaby"
+LABEL org.opencontainers.image.authors "https://github.com/obervinov"
 LABEL org.opencontainers.image.source "https://github.com/locustbaby/trivy-ui"
 LABEL org.opencontainers.image.version ${IMAGE_VERSION}
 


### PR DESCRIPTION
## v1.4.4 - 2025-04-15
### What's Changed
**Full Changelog**: https://github.com/obervinov/images/compare/v1.4.3...v1.4.4 by @obervinov in https://github.com/obervinov/images/pull/32
#### 🚀 Features
* Add new image `smartctl-exporter` for smartctl exporter
* Switch source repository for `trivy-ui` image to `locustbaby/trivy-ui`


