### PR TITLE
Release v1.4.6: Add `parallel` and updated dependencies in `debug` and `backup-tools` images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### What's Changed
 **Full Changelog**: https://github.com/obervinov/images/compare/v1.4.5...v1.4.6 by @obervinov in https://github.com/obervinov/images/pull/34
 #### 🚀 Features
-* Added `parallel`and update dependencies in the `debug` and `backup-tools` images
+* Added `parallel` and update dependencies in the `debug` and `backup-tools` images
 
 
 ## v1.4.5 - 2025-05-10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
 
+## v1.4.6 - 2025-05-14
+### What's Changed
+**Full Changelog**: https://github.com/obervinov/images/compare/v1.4.5...v1.4.6 by @obervinov in https://github.com/obervinov/images/pull/34
+#### 🚀 Features
+* Added `parallel`and update dependencies in the `debug` and `backup-tools` images
+
+
 ## v1.4.5 - 2025-05-10
 ### What's Changed
 **Full Changelog**: https://github.com/obervinov/images/compare/v1.4.4...v1.4.5 by @obervinov in https://github.com/obervinov/images/pull/33

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
 
-## v1.4.6 - 2025-05-14
+## v1.4.6 - 2025-05-15
 ### What's Changed
 **Full Changelog**: https://github.com/obervinov/images/compare/v1.4.5...v1.4.6 by @obervinov in https://github.com/obervinov/images/pull/34
 #### 🚀 Features

--- a/docker/backup-tools/Dockerfile
+++ b/docker/backup-tools/Dockerfile
@@ -1,8 +1,8 @@
 ### VERSIONS METADATA ###
-ARG IMAGE_VERSION=1.0.2
-ARG ALPINE_VERSION=3.20
-ARG GO_VERSION=1.22.5
-ARG VAULT_VERSION=1.17.2
+ARG IMAGE_VERSION=1.0.3
+ARG ALPINE_VERSION=3.21
+ARG GO_VERSION=1.24.3
+ARG VAULT_VERSION=1.19.3
 ### END VERSIONS METADATA ###
 
 
@@ -70,7 +70,8 @@ RUN apk -U upgrade && \
     zip \
     postgresql \
     s3cmd \
-    rsync
+    rsync \
+    parallel
 
 COPY --from=vault-builder /usr/local/bin/vault /usr/local/bin/vault
 COPY --from=rclone-builder /usr/local/bin/rclone /usr/local/bin/rclone

--- a/docker/backup-tools/README.md
+++ b/docker/backup-tools/README.md
@@ -17,13 +17,14 @@ This Docker image contains a collection of tools for backing up and restoring da
   - `rsync`: Utility for efficiently transferring and synchronizing files between systems.
   - `rclone`: Command-line program to manage files on cloud storage.
   - `vault`: A tool for managing secrets.
+  - `parallel`: A shell tool for executing jobs in parallel.
 
 ## Usage
 
 To use this image, you can pull it from Docker Hub using the following command:
 
 ```bash
-docker pull obervinov/images/backup-tools:1.0.2
+docker pull obervinov/images/backup-tools:1.0.3
 ```
 
 Once pulled, you can run containers based on this image and use the included tools for backup and restore operations.
@@ -34,7 +35,7 @@ The source code for this Docker image is available on [GitHub](https://github.co
 
 ## Version
 
-This README corresponds to version 1.0.0 of the Docker image.
+This README corresponds to version 1.0.3 of the Docker image.
 
 ## Author
 

--- a/docker/debug/Dockerfile
+++ b/docker/debug/Dockerfile
@@ -1,5 +1,5 @@
 ### VERSIONS METADATA ###
-ARG IMAGE_VERSION=1.0.8
+ARG IMAGE_VERSION=1.0.9
 ARG UBUNTU_VERSION=24.10
 ### END VERSIONS METADATA ###
 
@@ -34,6 +34,7 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y \
     dnsutils \
     rsync \
     jq \
+    parallel \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/docker/debug/README.md
+++ b/docker/debug/README.md
@@ -23,6 +23,7 @@ This Docker image provides a collection of utilities essential for investigating
 - `awscli` (Amazon Web Services Command Line Interface)
 - `yq` (YAML processor)
 - `rsync` (Remote file synchronization utility)
+- `parallel`: A shell tool for executing jobs in parallel.
 
 ## Usage
 


### PR DESCRIPTION
## v1.4.6 - 2025-05-15
### What's Changed
**Full Changelog**: https://github.com/obervinov/images/compare/v1.4.5...v1.4.6 by @obervinov in https://github.com/obervinov/images/pull/34
#### 🚀 Features
* Added `parallel` and update dependencies in the `debug` and `backup-tools` images


