### PR TITLE
Release v1.4.7: Update Caddy image

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,7 +21,7 @@ jobs:
           - "docker/certbot"
           - "docker/debug"
           - "docker/ghub"
-          - "docker/glab"
+          # - "docker/glab"
           - "docker/gradle"
           - "docker/jupyterhub"
           - "docker/python"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -70,4 +70,4 @@ jobs:
           # Upload Trivy scan results
           curl -L -X POST -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -H "X-GitHub-Api-Version: 2022-11-28" https://api.github.com/repos/${{ github.repository }}/code-scanning/sarifs -d "{\"commit_sha\":\"${{ github.sha }}\",\"ref\":\"${{ github.ref }}\",\"sarif\":\"$(gzip -c trivy-results-${image_name}-${image_tag}.sarif | base64 -w 0)\"}"
         working-directory: ${{ matrix.directories }}
-        continue-on-error: true
+        continue-on-error: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
 
+## v1.4.7 - 2025-06-16
+### What's Changed
+**Full Changelog**: https://github.com/obervinov/images/compare/v1.4.6...v1.4.7 by @obervinov in https://github.com/obervinov/images/pull/35
+#### 🚀 Features
+* Add `cloudflare-dns` plugin to the `caddy` image
+#### 💥 Breaking Changes
+* Remove L4 load balancer plugin from the `caddy` image
+
+
 ## v1.4.6 - 2025-05-15
 ### What's Changed
 **Full Changelog**: https://github.com/obervinov/images/compare/v1.4.5...v1.4.6 by @obervinov in https://github.com/obervinov/images/pull/34

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
 
-## v1.4.7 - 2025-06-16
+## v1.4.7 - 2025-06-17
 ### What's Changed
 **Full Changelog**: https://github.com/obervinov/images/compare/v1.4.6...v1.4.7 by @obervinov in https://github.com/obervinov/images/pull/35
 #### 🚀 Features

--- a/docker/caddy/Dockerfile
+++ b/docker/caddy/Dockerfile
@@ -1,7 +1,7 @@
 ### VERSIONS METADATA ###
-ARG IMAGE_VERSION=2.9.1-rev1
+ARG IMAGE_VERSION=2.10.0
 ARG GOLANG_VERSION=1.24.1-alpine3.21
-ARG CADDY_VERSION=2.9.1
+ARG CADDY_VERSION=2.10.0
 ### END VERSIONS METADATA ###
 
 
@@ -19,7 +19,7 @@ RUN git clone "https://github.com/caddyserver/caddy.git" && \
 
 WORKDIR /tmp/caddy/cmd/caddy
 RUN go install github.com/caddyserver/xcaddy/cmd/xcaddy@latest
-RUN xcaddy build \
+RUN xcaddy build v${CADDY_VERSION} \
     --with github.com/caddy-dns/digitalocean \
     --with github.com/shift72/caddy-geo-ip \
     --with github.com/caddy-dns/cloudflare \

--- a/docker/caddy/Dockerfile
+++ b/docker/caddy/Dockerfile
@@ -8,7 +8,6 @@ ARG CADDY_VERSION=2.9.1
 # Build binary with plugins
 FROM golang:${GOLANG_VERSION} AS builder
 
-ARG CADDY_VERSION
 
 WORKDIR /tmp
 RUN apk --no-cache add ca-certificates make git && update-ca-certificates

--- a/docker/caddy/Dockerfile
+++ b/docker/caddy/Dockerfile
@@ -8,6 +8,7 @@ ARG CADDY_VERSION=2.9.1
 # Build binary with plugins
 FROM golang:${GOLANG_VERSION} AS builder
 
+ARG CADDY_VERSION
 
 WORKDIR /tmp
 RUN apk --no-cache add ca-certificates make git && update-ca-certificates

--- a/docker/caddy/Dockerfile
+++ b/docker/caddy/Dockerfile
@@ -1,5 +1,5 @@
 ### VERSIONS METADATA ###
-ARG IMAGE_VERSION=2.9.1
+ARG IMAGE_VERSION=2.9.1-rev1
 ARG GOLANG_VERSION=1.24.1-alpine3.21
 ARG CADDY_VERSION=2.9.1
 ### END VERSIONS METADATA ###
@@ -8,16 +8,21 @@ ARG CADDY_VERSION=2.9.1
 # Build binary with plugins
 FROM golang:${GOLANG_VERSION} AS builder
 
+ARG CADDY_VERSION
+
 WORKDIR /tmp
 RUN apk --no-cache add ca-certificates make git && update-ca-certificates
-RUN git clone "https://github.com/caddyserver/caddy.git"
+RUN git clone "https://github.com/caddyserver/caddy.git" && \
+    cd caddy && \
+    git checkout v${CADDY_VERSION} && \
+    go mod download
 
 WORKDIR /tmp/caddy/cmd/caddy
 RUN go install github.com/caddyserver/xcaddy/cmd/xcaddy@latest
 RUN xcaddy build \
-    --with github.com/caddy-dns/digitalocean@master \
-    --with github.com/mholt/caddy-l4 \
+    --with github.com/caddy-dns/digitalocean \
     --with github.com/shift72/caddy-geo-ip \
+    --with github.com/caddy-dns/cloudflare \
     --output /usr/bin/caddy
 
 
@@ -26,7 +31,7 @@ FROM caddy:${CADDY_VERSION}-alpine AS caddy
 
 ARG IMAGE_VERSION
 
-LABEL org.opencontainers.image.description "This image contains a caddy with dns plugin https://github.com/caddy-dns/digitalocean"
+LABEL org.opencontainers.image.description "This image contains a caddy with dns plugins"
 LABEL org.opencontainers.image.url https://github.com/obervinov/images/docker/caddy
 LABEL org.opencontainers.image.documentation https://github.com/obervinov/images/docker/caddy/README.md
 LABEL org.opencontainers.image.authors https://github.com/obervinov

--- a/docker/caddy/README.md
+++ b/docker/caddy/README.md
@@ -1,6 +1,6 @@
 # Caddy Docker Image with Additional Plugins
 - DigitalOcean DNS plugin support
-- L4 Load Balancing
+- Cloudflare DNS plugin support
 - GeoIP
 
 This Docker image is designed to provide a custom Caddy server with additional plugins.
@@ -19,6 +19,5 @@ This Docker image is built in two stages:
 - **Documentation**: [GitHub Repository](https://github.com/obervinov/images/docker/caddy/README.md)
 - **Author**: [obervinov](https://github.com/obervinov)
 - **Source Code**: [GitHub Repository](https://github.com/obervinov/images/docker/caddy/Dockerfile)
-- **Version**: 2.9.1-alpine
 
 Feel free to customize this image according to your specific requirements and environment. If you encounter any issues or have suggestions for improvements, please don't hesitate to contribute to the GitHub repository.


### PR DESCRIPTION
## v1.4.7 - 2025-06-17
### What's Changed
**Full Changelog**: https://github.com/obervinov/images/compare/v1.4.6...v1.4.7 by @obervinov in https://github.com/obervinov/images/pull/35
#### 🚀 Features
* Add `cloudflare-dns` plugin to the `caddy` image
#### 💥 Breaking Changes
* Remove L4 load balancer plugin from the `caddy` image


