### PR TITLE
Fix v1.4.9: Restore JupyterHub image manifest and update dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
 
+## v1.4.9 - 2025-08-17
+### What's Changed
+**Full Changelog**: https://github.com/obervinov/images/compare/v1.4.8...v1.4.9 by @obervinov in https://github.com/obervinov/images/pull/37
+#### 🚀 Features
+* update jupyterhub image dependencies
+#### 🐛 Bug Fixes
+* restore jupyterhub image manifest
+
+
 ## v1.4.8 - 2025-07-26
 ### What's Changed
 **Full Changelog**: https://github.com/obervinov/images/compare/v1.4.7...v1.4.8 by @obervinov in https://github.com/obervinov/images/pull/36

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## v1.4.9 - 2025-08-17
 ### What's Changed
-**Full Changelog**: https://github.com/obervinov/images/compare/v1.4.8...v1.4.9 by @obervinov in https://github.com/obervinov/images/pull/37
+**Full Changelog**: https://github.com/obervinov/images/compare/v1.4.8...v1.4.9 by @obervinov in https://github.com/obervinov/images/pull/38
 #### 🚀 Features
 * update jupyterhub image dependencies
 #### 🐛 Bug Fixes

--- a/docker/jupyterhub/Dockerfile
+++ b/docker/jupyterhub/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/jupyterhub/k8s-singleuser-sample:4.1.0
+FROM quay.io/jupyterhub/k8s-singleuser-sample:4.2.0
 
 ARG IMAGE_VERSION=1.0.2
 


### PR DESCRIPTION
## v1.4.9 - 2025-08-17
### What's Changed
**Full Changelog**: https://github.com/obervinov/images/compare/v1.4.8...v1.4.9 by @obervinov in https://github.com/obervinov/images/pull/38
#### 🚀 Features
* update jupyterhub image dependencies
#### 🐛 Bug Fixes
* restore jupyterhub image manifest


