### PR TITLE
Release v1.4.12: Add clickhouse-client in Debug image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
 
-## v1.4.12 - 2025-12-25
+## v1.4.12 - 2025-12-26
 ### What's Changed
 **Full Changelog**: https://github.com/obervinov/images/compare/v1.4.11...v1.4.12 by @obervinov in https://github.com/obervinov/images/pull/42
 #### 🚀 Features
-* add `clickhouse-cli` tool to `debug` image
+* add `clickhouse-client` tool to `debug` image
 
 
 ## v1.4.11 - 2025-12-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
 
+## v1.4.12 - 2025-12-25
+### What's Changed
+**Full Changelog**: https://github.com/obervinov/images/compare/v1.4.11...v1.4.12 by @obervinov in https://github.com/obervinov/images/pull/42
+#### 🚀 Features
+* add `clickhouse-cli` tool to `debug` image
+
+
 ## v1.4.11 - 2025-12-23
 ### What's Changed
 **Full Changelog**: https://github.com/obervinov/images/compare/v1.4.10...v1.4.11 by @obervinov in https://github.com/obervinov/images/pull/41

--- a/docker/debug/Dockerfile
+++ b/docker/debug/Dockerfile
@@ -1,6 +1,6 @@
 ### VERSIONS METADATA ###
 ARG IMAGE_VERSION=1.0.10
-ARG UBUNTU_VERSION=24.10
+ARG UBUNTU_VERSION=26.04
 ### END VERSIONS METADATA ###
 
 
@@ -15,13 +15,21 @@ LABEL org.opencontainers.image.authors https://github.com/obervinov
 LABEL org.opencontainers.image.source https://github.com/obervinov/images
 LABEL org.opencontainers.image.version ${IMAGE_VERSION}
 
-RUN apt-get update && apt-get upgrade -y && apt-get install -y \
+RUN apt-get update && apt-get upgrade -y && apt-get install -y apt-transport-https ca-certificates gnupg curl 
+
+# ClickHouse repo
+RUN curl -fsSL 'https://packages.clickhouse.com/rpm/lts/repodata/repomd.xml.key' | gpg --dearmor -o /usr/share/keyrings/clickhouse-keyring.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/clickhouse-keyring.gpg] https://packages.clickhouse.com/ubuntu/ focal main" | tee /etc/apt/sources.list.d/clickhouse.list && \
+    ARCH=$(dpkg --print-architecture) && \
+    echo "deb [signed-by=/usr/share/keyrings/clickhouse-keyring.gpg arch=${ARCH}] https://packages.clickhouse.com/deb stable main" | tee /etc/apt/sources.list.d/clickhouse.list && \
+    apt-get update
+
+RUN apt-get install -y \
     software-properties-common \
     nmap \
     netcat-traditional \
     openssh-client \
     tcpdump \
-    curl \
     wget \
     strace \
     inetutils-ping \

--- a/docker/debug/Dockerfile
+++ b/docker/debug/Dockerfile
@@ -15,6 +15,7 @@ LABEL org.opencontainers.image.authors https://github.com/obervinov
 LABEL org.opencontainers.image.source https://github.com/obervinov/images
 LABEL org.opencontainers.image.version ${IMAGE_VERSION}
 
+# Base packages
 RUN apt-get update && apt-get upgrade -y && apt-get install -y apt-transport-https ca-certificates gnupg curl 
 
 # ClickHouse repo
@@ -24,6 +25,7 @@ RUN curl -fsSL 'https://packages.clickhouse.com/rpm/lts/repodata/repomd.xml.key'
     echo "deb [signed-by=/usr/share/keyrings/clickhouse-keyring.gpg arch=${ARCH}] https://packages.clickhouse.com/deb stable main" | tee /etc/apt/sources.list.d/clickhouse.list && \
     apt-get update
 
+# Debugging packages
 RUN apt-get install -y \
     software-properties-common \
     nmap \

--- a/docker/debug/Dockerfile
+++ b/docker/debug/Dockerfile
@@ -49,12 +49,15 @@ RUN apt-get install -y \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
+# Copy custom scripts and binaries
 COPY bin/ /usr/local/bin/
 
+# Install not available via apt packages
+# AWS CLI v2
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" &&\
     unzip awscliv2.zip &&\
     ./aws/install
-
+# YQ
 RUN wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 &&\
     chmod a+x /usr/local/bin/yq
 

--- a/docker/debug/Dockerfile
+++ b/docker/debug/Dockerfile
@@ -1,5 +1,5 @@
 ### VERSIONS METADATA ###
-ARG IMAGE_VERSION=1.0.9
+ARG IMAGE_VERSION=1.0.10
 ARG UBUNTU_VERSION=24.10
 ### END VERSIONS METADATA ###
 
@@ -35,6 +35,7 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y \
     rsync \
     jq \
     parallel \
+    clickhouse-client \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/docker/debug/README.md
+++ b/docker/debug/README.md
@@ -24,6 +24,7 @@ This Docker image provides a collection of utilities essential for investigating
 - `yq` (YAML processor)
 - `rsync` (Remote file synchronization utility)
 - `parallel`: A shell tool for executing jobs in parallel.
+- `clickhouse-client`: Command-line client for ClickHouse database.
 
 ## Usage
 


### PR DESCRIPTION
## v1.4.12 - 2025-12-26
### What's Changed
**Full Changelog**: https://github.com/obervinov/images/compare/v1.4.11...v1.4.12 by @obervinov in https://github.com/obervinov/images/pull/42
#### 🚀 Features
* add `clickhouse-client` tool to `debug` image


